### PR TITLE
New variables added (MLD + U/VFLX)

### DIFF
--- a/plot_geo_map.R
+++ b/plot_geo_map.R
@@ -24,49 +24,74 @@ if (compsize == 4) {
   codes_out4 <- codes_out[[4]]
 }
 
-# Make plots for each variable (if the variable isn't spatially explicit, this won't make sense)
+# Make plots for each variable (if the variable isn't spatially explicit, this won't make sense, but that's okay) - try later with ggplot??
+zmax <- max(abs(min(codes_out1)),max(codes_out1))
+zmin <- -zmax
 dev.new()
-par(mfrow=c(sdim2,sdim1))
+#par(mfrow=c(sdim2,sdim1))
+par(mfrow=c(sdim2,sdim1),
+    oma = c(5,4,0,0) + 0.1,
+    mar = c(0,0,1,1) + 0.1)
   for (node in c(1:nodes)){
-    dummy <- matrix(data=NA,nrow=length(lonvecM1),ncol=length(latvecM1))
-    dummy[seaindsM1]<-codes_out1[node,]
-    filled.contour3(x=lonvecM1, y=rev(latvecM1), dummy, xlim=c(120,240), ylim=c(60,20),  zlim=c(-2.5,2.5), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')), main=paste('Var 1, node', node))  #this works, but doesn't mask out the land
+#    dummy <- matrix(data=NA,nrow=length(lonvecM1),ncol=length(latvecM1))
+    dummyT <- matrix(data=NA,nrow=length(latvecM1),ncol=length(lonvecM1))
+    dummyT[seaindsM1]<-codes_out1[node,]
+    dummy <- t(dummyT)
+          filled.contour3(x=lonvecM1, y=latvecM1, dummy, xlim=c(lonmin,lonmax), ylim=c(latmin,latmax), zlim=c(zmin,zmax), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')), main=paste(sprintf('%s', grids[1]), 'node', node))  #this works, but doesn't mask out the land
   }
 par(new = "TRUE",plt = c(0.85,0.9,0.25,0.85),las = 1,cex.axis = 1)
-filled.legend(x=lonvecM1, y=rev(latvecM1), dummy, xlim=c(120,240), ylim=c(60,20),  zlim=c(-2.5,2.5), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu'))) 
-
+filled.legend(x=lonvecM1, y=latvecM1[order(latvecM1)], dummy, xlim=c(lonmin,lonmax), ylim=c(latmax,latmin),  zlim=c(zmin,zmax), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu'))) 
 
 if (compsize > 1) {
+  zmax <- max(abs(min(codes_out2)),max(codes_out2))
+  zmin <- -zmax
 dev.new()
-par(mfrow=c(sdim2,sdim1))
+#par(mfrow=c(sdim2,sdim1))
+par(mfrow=c(sdim2,sdim1),
+    oma = c(5,4,0,0) + 0.1,
+    mar = c(0,0,1,1) + 0.1)
   for (node in c(1:nodes)){
-    dummy <- matrix(data=NA,nrow=length(lonvecM2),ncol=length(latvecM2))
-    dummy[seaindsM2]<-codes_out2[node,]
-    filled.contour3(x=lonvecM2, y=rev(latvecM2), dummy, xlim=c(120,240), ylim=c(60,20), zlim=c(-2.5,2.5), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')), main=paste('Var 2, node', node))  #this works, but doesn't mask out the land
+    dummyT <- matrix(data=NA,nrow=length(latvecM2),ncol=length(lonvecM2))
+    dummyT[seaindsM2]<-codes_out2[node,]
+    dummy <- t(dummyT)
+      filled.contour3(x=lonvecM2, y=latvecM2, dummy, xlim=c(lonmin,lonmax), ylim=c(latmin,latmax), zlim=c(zmin,zmax), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')), main=paste(sprintf('%s', grids[2]), 'node', node))  #this works, but doesn't mask out the land
   }
 par(new = "TRUE",plt = c(0.85,0.9,0.25,0.85),las = 1,cex.axis = 1)
-filled.legend(x=lonvecM2, y=rev(latvecM2), dummy, xlim=c(120,240), ylim=c(60,20), zlim=c(-2.5,2.5), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')))  
+filled.legend(x=lonvecM2, y=latvecM2[order(latvecM2)], dummy, xlim=c(lonmin,lonmax), ylim=c(latmax,latmin), zlim=c(zmin,zmax), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')))  
 }
 
 if (compsize > 2) {
+  zmax <- max(abs(min(codes_out3)),max(codes_out3))
+  zmin <- -zmax
   dev.new()
-  par(mfrow=c(sdim2,sdim1))
+  #par(mfrow=c(sdim2,sdim1))
+  par(mfrow=c(sdim2,sdim1),
+      oma = c(5,4,0,0) + 0.1,
+      mar = c(0,0,1,1) + 0.1)
   for (node in c(1:nodes)){
-    dummy <- matrix(data=NA,nrow=length(lonvecM3),ncol=length(latvecM3))
-    dummy[seaindsM3]<-codes_out3[node,]
-    filled.contour3(x=lonvecM3, y=rev(latvecM3), dummy, xlim=c(120,240), ylim=c(60,20), zlim=c(-2.5,2.5), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')), main=paste('Var 3, node', node))  #this works, but doesn't mask out the land
+    dummyT <- matrix(data=NA,nrow=length(latvecM3),ncol=length(lonvecM3))
+    dummyT[seaindsM3]<-codes_out3[node,]
+    dummy <- t(dummyT)
+      filled.contour3(x=lonvecM3, y=latvecM3, dummy, xlim=c(lonmin,lonmax), ylim=c(latmin,latmax), zlim=c(zmin,zmax), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')), main=paste(sprintf('%s', grids[3]), 'node', node))  #this works, but doesn't mask out the land
   }
   par(new = "TRUE",plt = c(0.85,0.9,0.25,0.85),las = 1,cex.axis = 1)
-  filled.legend(x=lonvecM3, y=rev(latvecM3), dummy, xlim=c(120,240), ylim=c(60,20), zlim=c(-2.5,2.5), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')))  
-}
+  filled.legend(x=lonvecM3, y=latvecM3[order(latvecM3)], dummy, xlim=c(lonmin,lonmax), ylim=c(latmax,latmin), zlim=c(zmin,zmax), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')))  
+  }
+  
 if (compsize > 3) {
+  zmax <- max(abs(min(codes_out4)),max(codes_out4))
+  zmin <- -zmax
   dev.new()
-  par(mfrow=c(sdim2,sdim1))
+  #par(mfrow=c(sdim2,sdim1))
+  par(mfrow=c(sdim2,sdim1),
+      oma = c(5,4,0,0) + 0.1,
+      mar = c(0,0,1,1) + 0.1)
   for (node in c(1:nodes)){
-    dummy <- matrix(data=NA,nrow=length(lonvecM4),ncol=length(latvecM4))
-    dummy[seaindsM4]<-codes_out4[node,]
-    filled.contour3(x=lonvecM4, y=rev(latvecM4), dummy, xlim=c(120,240), ylim=c(60,20), zlim=c(-2.5,2.5), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')), main=paste('Var 4, node', node))  #this works, but doesn't mask out the land
+    dummyT <- matrix(data=NA,nrow=length(latvecM4),ncol=length(lonvecM4))
+    dummyT[seaindsM4]<-codes_out4[node,]
+    dummy <- t(dummyT)
+      filled.contour3(x=lonvecM4, y=latvecM4, dummy, xlim=c(lonmin,lonmax), ylim=c(latmin,latmax), zlim=c(zmin,zmax), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')), main=paste(sprintf('%s', grids[4]), 'node', node))  #this works, but doesn't mask out the land
   }
   par(new = "TRUE",plt = c(0.85,0.9,0.25,0.85),las = 1,cex.axis = 1)
-  filled.legend(x=lonvecM4, y=rev(latvecM4), dummy, xlim=c(120,240), ylim=c(60,20), zlim=c(-2.5,2.5), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')))  
+  filled.legend(x=lonvecM4, y=latvecM4[order(latvecM4)], dummy, xlim=c(lonmin,lonmax), ylim=c(latmax,latmin), zlim=c(zmin,zmax), nlevels=10, col = rev(brewer.pal(n=10,name='RdBu')))  
 }

--- a/runSOM_xyf_super.R
+++ b/runSOM_xyf_super.R
@@ -17,31 +17,53 @@ setwd('/Users/emilynorton/Documents/FATE_Hunsicker_Bond_OcnAtmCoupling/RScripts/
 set.seed(9)   
 
 # Set number of variables we're going to compare 
-compsize <- 4   #1 = univariable "som", 2 = two co-variable "xyf", 3 or more = multivariable "supersom"
+compsize <- 2   #1 = univariable "som", 2 = two co-variable "xyf", 3 or more = multivariable "supersom"
 
 #set variable filenames to load - only has data for the sea points
 #NOTE: these files must contain headers and 'year' column, and must *at least* contain the temporal range of interest
+#Non-spatially explicit data:
 #file1 <- '../BiologyData/goa.biology.pca.1965.2012.csv'        # Contains V1 and V2
-file1 <- '../BiologyData/goa.biology.pca.1965.2012_V1only.csv'  # Contains V1 only
-#file1 <- '../PhysicalData/MonthlyAverages/MonthlyAvg11to3_forYears1948to2018_hgt.csv'     # Geopotential height at 200mbar (hPa)
-file2 <- '../PhysicalData/MonthlyAverages/MonthlyAvg11to3_forYears1948to2018_skt.csv'     # Skin Temp
-file3 <- '../PhysicalData/MonthlyAverages/MonthlyAvg11to1_forYears1948to2018_slp.csv'     # Sea Level Pressure
-#file4 <- '../PhysicalData/pdo_1900to2018_FebtoApr_avg.csv'     # PDO averaged Feb to Apr
-file4 <- '../PhysicalData/npgo_1950to2018_FebtoApr_avg.csv'     # NPGO averaged Feb to Apr
+#file1 <- '../BiologyData/goa.biology.pca.1965.2012_V1only.csv'  # Contains V1 only
+#file1 <- '../BiologyData/groundfish1.csv'
+#file2 <- '../BiologyData/groundfish3.csv'
+#file2 <- '../PhysicalData/pdo_1900to2018_FebtoApr_avg.csv'     # PDO averaged Feb to Apr
+#file4 <- '../PhysicalData/npgo_1950to2018_FebtoApr_avg.csv'     # NPGO averaged Feb to Apr
 
-# Set variable grid sizes: "SLP"/"HGT" (both same grid) or "SKT". If strictly timeseries var (e.g. biol V1), it doesn't matter what you choose - the slp grid will be used - so just use the variable name
-vargrid1 <- "biolV1"
+#re-shaped spatially explicit data
+#file4 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds20to65N_120to255E_MLD.csv'   #MLD only available 1959-2011
+#file4 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds40to65N_170to235E_MLD.csv'  
+file2 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds20to65N_120to255E_skt_detrend_incLat.csv'  #skt avail 1948 - 2018
+#file1 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds40to65N_170to235E_skt_detrend_incLat.csv'
+file1 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds20to65N_120to255E_slp_incLat.csv'  #slp avail 1948 - 2018
+#file1 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds40to65N_170to235E_slp_incLat.csv'
+#file2 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds20to65N_120to255E_UFLX.csv'    #UFLX avail 1948 - 2018
+#file2 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds40to65N_170to235E_UFLX.csv' 
+#file3 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds20to65N_120to255E_VFLX.csv'    #VFLX avail 1948 - 2018
+#file3 <- '../PhysicalData/Averages_Reshaped/MonthlyAvg11to3_forYears1948to2018_Bounds40to65N_170to235E_VFLX.csv'  
+
+
+
+# Set variable grid sizes: "SLP"/"HGT" (both same grid), "SKT", "MLD", "UFLX", or "VFLX". If strictly timeseries var (e.g. biol V1), which doesn't have
+# a spatial grid, it doesn't matter what you choose - the slp grid will be used by default - so just use the variable name
+vargrid1 <- "SLP"
 vargrid2 <- "SKT" 
-vargrid3 <- "SLP"
-vargrid4 <- "npgo"
+vargrid3 <- "VFLX"
+vargrid4 <- "MLD"
 
 # Set temporal range of interest  **THIS IS NEW!! And allows you to re-use input files with longer temporal ranges
-yearmin <- 1965
-yearmax <- 2012
+yearmin <- 1948
+yearmax <- 2018
+
+# Set spatial boundaries for the map grid  (seasonal averaged files must already be generated with these bounds - use matlab script "Average_PickYourMonths_SpatialBounds.m"
+# and then add a "year" column and header row)
+latmin = 20
+latmax = 65
+lonmin = 120
+lonmax = 255
 
 #set dimensions for the som grid (2D) and shape of somgrid (options: 'hexagonal','rectangular')
-sdim1 <- 3 
-sdim2 <- 2
+sdim1 <- 5 
+sdim2 <- 6
 sshape <- 'hexagonal' 
 
 # set relative weights for each variable (up to 4 variables)
@@ -59,12 +81,12 @@ booYearNode <- 'T'
 booGeoMap <- 'T'
 
 # Plot title name and name to save plots
-title_name <- "Test superSOM of HGT, SKT, SLP for 1948-2018"   
+title_name <- "Reshaped SKT detrend 1948-2018"   
 plot_fname <- "test_plots"
 
 #Do you want to save SOM codes or maps as .csv files?
-saveCodes <- 'T'
-saveMaps <- 'T'
+saveCodes <- 'F'
+saveMaps <- 'F'
 
 # Code and map filenames  ###COME BACK TO THIS>>>need to save depending on number of vars, etc.
 codes1_fname <- sprintf("codes_SOM_%iby%i%sgrid_%ito%iyears_%s.csv", sdim1, sdim2, sshape, yearmin, yearmax, vargrid1)
@@ -91,6 +113,7 @@ data1_forSOM <- data1 %>%   #get rid of year column...may want to prepare in oth
   filter(year <= yearmax, year >= yearmin) %>%
   select(-year)
 
+
 if (compsize > 1) {
   data2 <- read_csv(file2)
   data2_forSOM <- data2 %>% 
@@ -112,23 +135,70 @@ if (compsize > 3){
     select(-year)
 }
 
-#set grid filenames to load, with only lat/lon for the sea points, and the indexing info for each point -NOTE: come back and fix this
-slpseaindsfile <- '../PhysicalData/slp_seainds.csv' 
-slplatvecfile <- '../PhysicalData/slp_lat_vec.csv'
-slplonvecfile <- '../PhysicalData/slp_lon_vec.csv'
 
-sktseaindsfile <- '../PhysicalData/skt_seainds.csv'
-sktlatvecfile <- '../PhysicalData/skt_lat_vec.csv'
-sktlonvecfile <- '../PhysicalData/skt_lon_vec.csv'
+#set grid filenames to load, with only lat/lon for the sea points, and the indexing info for each point - Updated 12/12/10 - reshaped grid
+# May need to change these file paths to match your directory structure
+#slpseaindsfile <- '../PhysicalData/slp_seainds.csv' 
+#slplatvecfile <- '../PhysicalData/slp_lat_vec.csv'
+#slplonvecfile <- '../PhysicalData/slp_lon_vec.csv'
 
+#sktseaindsfile <- '../PhysicalData/skt_seainds.csv'
+#sktlatvecfile <- '../PhysicalData/skt_lat_vec.csv'
+#sktlonvecfile <- '../PhysicalData/skt_lon_vec.csv'
+
+sktseaindsfile <- sprintf('../PhysicalData/Averages_Reshaped/skt_seainds_Bounds_OrigGrid_%ito%iN_%ito%iE_incLat.csv', latmin, latmax, lonmin, lonmax) 
+sktlatvecfile <- '../PhysicalData/Averages_Reshaped/skt_lat_vec_Bounds_OrigGrid_20to65N_120to255E_incLat.csv'
+sktlonvecfile <- '../PhysicalData/Averages_Reshaped/skt_lon_vec_Bounds_OrigGrid_20to65N_120to255E.csv'
+
+slpseaindsfile <- sprintf('../PhysicalData/Averages_Reshaped/slp_seainds_Bounds_OrigGrid_%ito%iN_%ito%iE_incLat.csv', latmin, latmax, lonmin, lonmax) 
+slplatvecfile <- '../PhysicalData/Averages_Reshaped/slp_lat_vec_Bounds_OrigGrid_20to65N_120to255E_incLat.csv'
+slplonvecfile <- '../PhysicalData/Averages_Reshaped/slp_lon_vec_Bounds_OrigGrid_20to65N_120to255E.csv'
+
+uflxseaindsfile <- sprintf('../PhysicalData/Averages_Reshaped/UFLX_seainds_Bounds_OrigGrid_%ito%iN_%ito%iE.csv', latmin, latmax, lonmin, lonmax) 
+uflxlatvecfile <- '../PhysicalData/Averages_Reshaped/UFLX_lat_vec_Bounds_OrigGrid_20to65N_120to255E.csv'
+uflxlonvecfile <- '../PhysicalData/Averages_Reshaped/UFLX_lon_vec_Bounds_OrigGrid_20to65N_120to255E.csv'
+
+vflxseaindsfile <- sprintf('../PhysicalData/Averages_Reshaped/VFLX_seainds_Bounds_OrigGrid_%ito%iN_%ito%iE.csv', latmin, latmax, lonmin, lonmax) 
+vflxlatvecfile <- '../PhysicalData/Averages_Reshaped/VFLX_lat_vec_Bounds_OrigGrid_20to65N_120to255E.csv'
+vflxlonvecfile <- '../PhysicalData/Averages_Reshaped/VFLX_lon_vec_Bounds_OrigGrid_20to65N_120to255E.csv'
+
+mldseaindsfile <- sprintf('../PhysicalData/Averages_Reshaped/MLD_seainds_Bounds_OrigGrid_%ito%iN_%ito%iE.csv', latmin, latmax, lonmin, lonmax) 
+mldlatvecfile <- '../PhysicalData/Averages_Reshaped/MLD_lat_vec_Bounds_OrigGrid_20to65N_120to255E.csv'
+mldlonvecfile <- '../PhysicalData/Averages_Reshaped/MLD_lon_vec_Bounds_OrigGrid_20to65N_120to255E.csv'
+
+glist <- c(vargrid1, vargrid2, vargrid3, vargrid4)
+grids <- glist[1:compsize]
+
+if (sum(grepl("SLP", grids, fixed=TRUE))>0){
 slpseainds <- as.matrix(read.csv(slpseaindsfile, header = FALSE)) 
 slplatvec <-as.matrix(read.csv(slplatvecfile, header=FALSE))
 slplonvec <-as.matrix(read.csv(slplonvecfile, header=FALSE))
+}
 
+if (sum(grepl("SKT", grids, fixed=TRUE))>0){
 sktseainds <- as.matrix(read.csv(sktseaindsfile, header = FALSE)) 
 sktlatvec <-as.matrix(read.csv(sktlatvecfile, header=FALSE))
 sktlonvec <-as.matrix(read.csv(sktlonvecfile, header=FALSE))
-  
+}
+
+if (sum(grepl("UFLX", grids, fixed=TRUE))>0){
+uflxseainds <- as.matrix(read.csv(uflxseaindsfile, header = FALSE)) 
+uflxlatvec <-as.matrix(read.csv(uflxlatvecfile, header=FALSE))
+uflxlonvec <-as.matrix(read.csv(uflxlonvecfile, header=FALSE))
+}
+
+if (sum(grepl("VFLX", grids, fixed=TRUE))>0){
+vflxseainds <- as.matrix(read.csv(vflxseaindsfile, header = FALSE)) 
+vflxlatvec <-as.matrix(read.csv(vflxlatvecfile, header=FALSE))
+vflxlonvec <-as.matrix(read.csv(vflxlonvecfile, header=FALSE))
+}
+
+if (sum(grepl("MLD", grids, fixed=TRUE))>0){
+mldseainds <- as.matrix(read.csv(mldseaindsfile, header = FALSE)) 
+mldlatvec <-as.matrix(read.csv(mldlatvecfile, header=FALSE))
+mldlonvec <-as.matrix(read.csv(mldlonvecfile, header=FALSE))
+}
+
 
 # Load grid files in as matrices, and the indices ('seainds') where the data are from - NOTE: 'SLP' (sea level pressure)
 # and 'HGT' (geopotential height at 200mbar) have the same grid and sea indices
@@ -136,6 +206,18 @@ if (vargrid1 == 'SKT') {
 seaindsM1 <- sktseainds
 latvecM1 <- sktlatvec
 lonvecM1 <- sktlonvec
+} else if (vargrid1 == 'UFLX') {
+  seaindsM1 <- uflxseainds
+  latvecM1 <- uflxlatvec
+  lonvecM1 <- uflxlonvec
+} else if (vargrid1 == 'VFLX') {
+  seaindsM1 <- vflxseainds
+  latvecM1 <- vflxlatvec
+  lonvecM1 <- vflxlonvec
+} else if (vargrid1 == 'MLD') {
+  seaindsM1 <- mldseainds
+  latvecM1 <- mldlatvec
+  lonvecM1 <- mldlonvec
 } else {                       # if vargrid 1 == "SLP" | vargrid2 == 'HGT' (or anything else, assume slp-sized grid)
 seaindsM1 <- slpseainds
 latvecM1 <- slplatvec
@@ -147,6 +229,18 @@ if (compsize > 1) {
     seaindsM2 <- sktseainds
     latvecM2 <- sktlatvec
     lonvecM2 <- sktlonvec
+  } else if (vargrid2 == 'UFLX') {
+    seaindsM2 <- uflxseainds
+    latvecM2 <- uflxlatvec
+    lonvecM2 <- uflxlonvec
+  } else if (vargrid2 == 'VFLX') {
+    seaindsM2 <- vflxseainds
+    latvecM2 <- vflxlatvec
+    lonvecM2 <- vflxlonvec
+  } else if (vargrid2 == 'MLD') {
+    seaindsM2 <- mldseainds
+    latvecM2 <- mldlatvec
+    lonvecM2 <- mldlonvec
   } else {
     seaindsM2 <- slpseainds
     latvecM2 <- slplatvec
@@ -159,6 +253,18 @@ if (compsize > 2) {
     seaindsM3 <- sktseainds
     latvecM3 <- sktlatvec
     lonvecM3 <- sktlonvec
+  } else if (vargrid3 == 'UFLX') {
+    seaindsM3 <- uflxseainds
+    latvecM3 <- uflxlatvec
+    lonvecM3 <- uflxlonvec
+  } else if (vargrid3 == 'VFLX') {
+    seaindsM3 <- vflxseainds
+    latvecM3 <- vflxlatvec
+    lonvecM3 <- vflxlonvec
+  } else if (vargrid3 == 'MLD') {
+    seaindsM3 <- mldseainds
+    latvecM3 <- mldlatvec
+    lonvecM3 <- mldlonvec
   } else {
     seaindsM3 <- slpseainds
     latvecM3 <- slplatvec
@@ -171,6 +277,18 @@ if (compsize > 3) {
     seaindsM4 <- sktseainds
     latvecM4 <- sktlatvec
     lonvecM4 <- sktlonvec
+  } else if (vargrid4 == 'UFLX') {
+    seaindsM4 <- uflxseainds
+    latvecM4 <- uflxlatvec
+    lonvecM4 <- uflxlonvec
+  } else if (vargrid4 == 'VFLX') {
+    seaindsM4 <- vflxseainds
+    latvecM4 <- vflxlatvec
+    lonvecM4 <- vflxlonvec
+  } else if (vargrid4 == 'MLD') {
+    seaindsM4 <- mldseainds
+    latvecM4 <- mldlatvec
+    lonvecM4 <- mldlonvec
   } else {
     seaindsM4 <- slpseainds
     latvecM4 <- slplatvec
@@ -203,7 +321,6 @@ codes_out <- getCodes(som_out)
 #Get maps for the SOM
 maps_out <- map(som_out)
 
-##THIS NEEDS TO BE MODIFIED FOR THE LENGTH OF CODES... if two variables, then two lists, etc.
 
 # Save codes and maps, if desired
 if (saveCodes == 'T') {
@@ -239,5 +356,5 @@ if (booYearNode == 'T') {
 
 #Generate geographic map of averaged codes for each node
 if (booGeoMap == 'T') {
-    source('plot_geo_map.r')
+    source('plot_geo_map_reshaped.r')
 }


### PR DESCRIPTION
Input .csv files have been re-shaped so now we're reading first across latitudes (from low to high, i.e. equator to pole) for a given longitude, and then moving across longitudes.  This does not impact the output of the SOM, but the red squiggly code plots do look different - no need to be alarmed.  Mixed layer depth (MLD) and u/v flux (UFLX, VFLX) data have been prepared as input files for the full domain (MLD = 40 - 65N, 170-235E; U/VFLX: 20-68N, 130-250E) and for partial domain (40-65N, 170-235E).  Corresponding grids have been made to allow geospatial plotting of the code results for these variables.  [Note that MLD is available only from ORAS3 from 1959 - 2011, while U/VFLX is available from NCEP from 1948 -2018.]  SKT + SLP input data files have also been changed so that their latitude vector is ascending, which makes plotting easier and consistent with the other variables.  We can now run SOMs on the full domain or any partial domain of choice, as long as the input files are prepared accordingly - this is done in Matlab with "Average_PickYourMonths_SpatialBounds.m'.  Geospatial mapping has been improved so that more maps can fit on the same page, which is handy for running SOMs with more nodes; plot titles have also been improved. I would still like to re-order the plots to match the automated Kohonen plots - this is still on my to-do list.